### PR TITLE
Add APP_LOCALE for German Plex library names

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ services:
       - PLEX_TOKEN=YOUR_PLEX_TOKEN                  # Optional
       - JELLYFIN_URL=http://YOUR_JELLYFIN_IP:8096   # Optional
       - JELLYFIN_API_KEY=YOUR_JELLYFIN_API_KEY      # Optional
+      - APP_LOCALE=en                               # Optional: use de for Plex library "Filme"
       - FLASK_SECRET=SomeRandomString
       - TMDB_API_KEY=your_tmdb_key_here
     volumes:
@@ -134,6 +135,7 @@ docker run -d \
   -e PLEX_TOKEN=YOUR_PLEX_TOKEN \                   # Optional
   -e JELLYFIN_URL=http://YOUR_JELLYFIN_IP:8096 \    # Optional
   -e JELLYFIN_API_KEY=YOUR_JELLYFIN_API_KEY \       # Optional
+  -e APP_LOCALE=en \                                # Optional: use de for Plex library "Filme"
   -e FLASK_SECRET=SomeRandomString \
   -e TMDB_API_KEY=your_tmdb_key_here \
   -v ./data:/app/data \
@@ -143,6 +145,8 @@ docker run -d \
 ```
 
 > At least Plex or Jellyfin must be configured. Both can be also set at the same time.
+
+**Plex library locale (optional):** defaults to `en` (`Movies`). Set `APP_LOCALE=de` if your Plex movie library is named `Filme`.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -113,6 +113,11 @@ def reset_plex():
     _plex_instance = None
 
 def get_plex_movie_section(plex):
+    """Return the Plex movie library section for the configured APP_LOCALE.
+
+    Tries the locale-specific library name first (e.g. Movies / Filme),
+    then other known locale names, then the first movie-type library.
+    """
     library_name = PLEX_LIBRARY_BY_LOCALE.get(APP_LOCALE, PLEX_LIBRARY_BY_LOCALE['en'])
     try:
         return plex.library.section(library_name)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, send_from_directory, jsonify, request, session, Response, render_template, abort
 from plexapi.server import PlexServer
 from plexapi.myplex import MyPlexAccount
+from plexapi.exceptions import NotFound
 from werkzeug.middleware.proxy_fix import ProxyFix
 from contextlib import contextmanager
 import sqlite3, os, random, requests, json, secrets, time, threading
@@ -17,6 +18,13 @@ CLIENT_ID = 'KinoSwipe-Bergasha-2026'
 
 JELLYFIN_URL = os.getenv('JELLYFIN_URL', '').rstrip('/')
 JELLYFIN_API_KEY = os.getenv('JELLYFIN_API_KEY', '')
+
+APP_LOCALE = os.getenv('APP_LOCALE', 'en').lower()
+
+PLEX_LIBRARY_BY_LOCALE = {
+    'en': 'Movies',
+    'de': 'Filme',
+}
 
 CACHE_TTL = 43200        
 CACHE_TTL_RECENT = 1800  
@@ -104,13 +112,32 @@ def reset_plex():
     global _plex_instance
     _plex_instance = None
 
+def get_plex_movie_section(plex):
+    library_name = PLEX_LIBRARY_BY_LOCALE.get(APP_LOCALE, PLEX_LIBRARY_BY_LOCALE['en'])
+    try:
+        return plex.library.section(library_name)
+    except NotFound:
+        pass
+
+    for name in PLEX_LIBRARY_BY_LOCALE.values():
+        try:
+            return plex.library.section(name)
+        except NotFound:
+            continue
+
+    for section in plex.library.sections():
+        if section.type == 'movie':
+            return section
+
+    raise NotFound('No Plex movie library found')
+
 def get_plex_genres():
     global _plex_genre_cache
     if _plex_genre_cache is not None:
         return _plex_genre_cache
     try:
         plex = get_plex()
-        section = plex.library.section('Movies')
+        section = get_plex_movie_section(plex)
         genres = sorted({g.title for g in section.listFilterChoices(field='genre')})
         display = ["Sci-Fi" if g == "Science Fiction" else g for g in genres]
         _plex_genre_cache = display
@@ -121,11 +148,11 @@ def get_plex_genres():
 def fetch_plex_movies(genre_name=None):
     try:
         plex = get_plex()
-        movie_section = plex.library.section('Movies')
+        movie_section = get_plex_movie_section(plex)
     except Exception:
         reset_plex()
         plex = get_plex()
-        movie_section = plex.library.section('Movies')
+        movie_section = get_plex_movie_section(plex)
     search_genre = "Science Fiction" if genre_name == "Sci-Fi" else genre_name
 
     if genre_name == "Recently Added":

--- a/docker run.txt
+++ b/docker run.txt
@@ -3,6 +3,7 @@ docker run -d \
   -p 5005:5005 \
   -e PLEX_URL="https://YOUR_PLEX_URL" \
   -e PLEX_TOKEN="YOUR_PLEX_TOKEN" \
+  -e APP_LOCALE="en" \
   -v kino_data:/app/data \
   --restart unless-stopped \
   bergasha/kino-swipe:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PLEX_URL=https://your-plex-ip:32400
       - PLEX_TOKEN=your-plex-token-here
+      - APP_LOCALE=en
       - FLASK_SECRET=pick-a-random-string
     volumes:
       - ./data:/app/data


### PR DESCRIPTION
Add optional APP_LOCALE env var (defaults to en).
en uses Plex library section Movies; de uses Filme. Falls back to the other locale name, then auto-detects the first movie library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale configuration support for Plex library selection, allowing users to specify which language-named Plex movie library to use (e.g., "Filme" for German). Defaults to English locale with "Movies" library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bergasha/kino-swipe/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->